### PR TITLE
fix: make questionnaire questions scrollable on iOS

### DIFF
--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -1289,6 +1289,9 @@ header {
   border-top: 1px solid var(--border-color);
   flex-shrink: 0;
   z-index: 10;
+  display: flex;
+  flex-direction: column;
+  max-height: 55vh;
 }
 
 .questionnaire-bar.hidden { display: none; }
@@ -1298,6 +1301,7 @@ header {
   align-items: center;
   gap: 6px;
   margin-bottom: 10px;
+  flex-shrink: 0;
 }
 
 .questionnaire-icon { font-size: 14px; }
@@ -1312,6 +1316,14 @@ header {
   font-size: 11px;
   color: var(--text-secondary);
   margin-left: auto;
+}
+
+#questionnaire-questions {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  min-height: 0;
+  flex: 1;
 }
 
 .questionnaire-question {
@@ -1379,6 +1391,7 @@ header {
   display: flex;
   gap: 10px;
   margin-top: 6px;
+  flex-shrink: 0;
 }
 
 .btn-q-skip {


### PR DESCRIPTION
## Summary

- Questionnaire questions were not scrollable on iOS — when multiple questions appeared, content overflowed off-screen with no way to reach it
- Root cause: `.questionnaire-bar` had `flex-shrink: 0` with no height constraint or `overflow` handling, and the root `html/body` has `overflow: hidden`
- Caps the questionnaire bar at `max-height: 55vh` with flex column layout, makes `#questionnaire-questions` independently scrollable with iOS momentum scrolling, and pins the header/action buttons so only the question list scrolls

## Changes

- `.questionnaire-bar` — added `display: flex; flex-direction: column; max-height: 55vh`
- `#questionnaire-questions` — new rule with `overflow-y: auto; -webkit-overflow-scrolling: touch; overscroll-behavior: contain; min-height: 0; flex: 1`
- `.questionnaire-header` and `.questionnaire-actions` — added `flex-shrink: 0` to keep them pinned

## Test plan

- [ ] Open web client on iOS Safari with 3+ questionnaire questions visible
- [ ] Verify the questions list scrolls independently with momentum
- [ ] Verify the header (icon + title + stepper) and action buttons (Skip / Continue) remain visible and fixed
- [ ] Verify short question lists (1-2 questions) render normally without unnecessary scroll
- [ ] Check on Android Chrome as well for cross-platform sanity


Made with [Cursor](https://cursor.com)