### PR TITLE
fix(server): glass sidebar agent rail for multi-agent chat tabs (#13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ scripts/generate-keys.ts
 azure_token
 openvsx_token
 # marketing/
+.specstory/

--- a/selectors.json
+++ b/selectors.json
@@ -48,7 +48,8 @@
   },
   "chatTabList": {
     "strategies": [
-      ".agent-sidebar-cell"
+      ".agent-sidebar-cell",
+      ".glass-sidebar-agent-list-container li.ui-sidebar-menu-item > div.glass-sidebar-agent-menu-btn"
     ]
   },
   "newChatButton": {

--- a/src/server/command-executor.ts
+++ b/src/server/command-executor.ts
@@ -151,21 +151,61 @@ export class CommandExecutor {
       const clicked = await client.evaluate(`
         (() => {
           const title = ${JSON.stringify(tabTitle)};
-          const norm = s => s.trim().replace(/\\s+/g, ' ');
-          const target = norm(title).toLowerCase();
+          const norm = s => s.trim().replace(/\\s+/g, ' ').toLowerCase();
+          const target = norm(title);
+          function cleanTabTitle(raw) {
+            let t = (raw || '').trim().replace(/\\s+/g, ' ');
+            t = t.replace(/(@[\\w./]+)+\\s*$/, '');
+            return t.trim().substring(0, 120);
+          }
+          function glassCompositeForBtn(btn) {
+            const labelEl = btn.querySelector('.ui-sidebar-menu-button-label');
+            const rawAgent = (labelEl?.textContent || '').trim();
+            if (!rawAgent) return { composite: '', agentOnly: '' };
+            const group = btn.closest('.ui-sidebar-group');
+            const gt = group?.querySelector('.ui-sidebar-group-label-title');
+            const rawGroup = (gt?.textContent || '').trim();
+            let composite = cleanTabTitle(rawAgent);
+            if (rawGroup) {
+              const g = cleanTabTitle(rawGroup);
+              if (g) composite = (g + ' / ' + cleanTabTitle(rawAgent)).substring(0, 120);
+            }
+            return { composite: norm(composite), agentOnly: norm(rawAgent) };
+          }
+          const glassBtns = Array.from(document.querySelectorAll(
+            '.glass-sidebar-agent-list-container li.ui-sidebar-menu-item > div.glass-sidebar-agent-menu-btn'
+          ));
+          if (glassBtns.length > 0) {
+            const rows = glassBtns.map((btn) => ({
+              btn,
+              ...glassCompositeForBtn(btn),
+            })).filter((r) => r.composite);
+            const byComp = rows.filter((r) => r.composite === target);
+            if (byComp.length === 1) {
+              byComp[0].btn.click();
+              return true;
+            }
+            const byAgent = rows.filter((r) => r.agentOnly === target);
+            if (byAgent.length === 1) {
+              byAgent[0].btn.click();
+              return true;
+            }
+            if (byComp.length > 1 || byAgent.length > 1) {
+              throw new Error('Ambiguous tab title for glass sidebar: ' + title);
+            }
+          }
           const cells = document.querySelectorAll('.agent-sidebar-cell');
           for (const cell of Array.from(cells)) {
             const titleEl = cell.querySelector('.agent-sidebar-cell-text');
-            const text = norm(titleEl ? (titleEl.textContent || '') : (cell.textContent || '')).toLowerCase();
+            const text = norm(titleEl ? (titleEl.textContent || '') : (cell.textContent || ''));
             if (text === target) {
               cell.click();
               return true;
             }
           }
-          // Prefix fallback: match normalized prefix
           for (const cell of Array.from(cells)) {
             const titleEl = cell.querySelector('.agent-sidebar-cell-text');
-            const text = norm(titleEl ? (titleEl.textContent || '') : (cell.textContent || '')).toLowerCase();
+            const text = norm(titleEl ? (titleEl.textContent || '') : (cell.textContent || ''));
             if (text.startsWith(target) || target.startsWith(text)) {
               cell.click();
               return true;

--- a/src/server/dom-extractor.ts
+++ b/src/server/dom-extractor.ts
@@ -1270,7 +1270,69 @@ export function extractionFunction(
           }
         }
       }
+      // Cursor Agents unified window: glass sidebar rows (replaces .agent-sidebar-cell in newer builds)
+      const glassTabRoots = document.querySelectorAll(
+        '.glass-sidebar-agent-list-container li.ui-sidebar-menu-item > div.glass-sidebar-agent-menu-btn'
+      );
+      if (glassTabRoots.length > 0) {
+        for (const tab of Array.from(glassTabRoots)) {
+          const labelEl = tab.querySelector('.ui-sidebar-menu-button-label');
+          const rawAgentTitle = (labelEl?.textContent || '').trim();
+          if (!rawAgentTitle) continue;
+
+          const group = tab.closest('.ui-sidebar-group');
+          const groupTitleEl = group?.querySelector('.ui-sidebar-group-label-title');
+          const rawGroupTitle = (groupTitleEl?.textContent || '').trim();
+
+          let displayTitle = cleanTabTitle(rawAgentTitle);
+          if (rawGroupTitle) {
+            const g = cleanTabTitle(rawGroupTitle);
+            if (g) {
+              displayTitle = `${g} / ${cleanTabTitle(rawAgentTitle)}`.substring(0, 120);
+            }
+          }
+
+          if (seenTitles.has(displayTitle)) continue;
+          seenTitles.add(displayTitle);
+
+          const composerId =
+            tab.getAttribute('data-composer-id')
+            || tab.closest('[data-composer-id]')?.getAttribute('data-composer-id')
+            || `glass:${displayTitle}`;
+
+          const isActive = tab.getAttribute('data-active') === 'true';
+
+          chatTabs.push({
+            composerId,
+            title: displayTitle,
+            isActive,
+            status: isActive ? 'active' : 'idle',
+            selectorPath: buildSelectorPath(tab),
+          });
+        }
+
+        if (containerComposerId) {
+          let matched = false;
+          for (const t of chatTabs) {
+            if (t.composerId === containerComposerId) {
+              matched = true;
+              t.isActive = true;
+              t.status = 'active';
+            }
+          }
+          if (matched) {
+            for (const t of chatTabs) {
+              if (t.composerId !== containerComposerId) {
+                t.isActive = false;
+                t.status = 'idle';
+              }
+            }
+          }
+        }
+      }
+
       for (const sel of chatTabSelectors) {
+        if (chatTabs.length > 0) break;
         let tabItems: NodeListOf<Element>;
         try {
           const root: Element | Document = scopeRoot || document;


### PR DESCRIPTION
## Summary
**Narrow PR** (single commit): Cursor Agents **glass sidebar** DOM (`glass-sidebar-agent-list-container` / `glass-sidebar-agent-menu-btn`) for `chatTabs` + `switchTab`, with legacy `.agent-sidebar-cell` fallback. No CDP proxy / Tailscale / discovery-tool changes in this branch.

## Refs
- Fixes https://github.com/len5ky/CursorRemote/issues/13

## Testing
- `npm test`
- `npm run build`