### PR TITLE
fix(server): scope approval detection to active composer (#12)

### DIFF
--- a/src/server/command-executor.ts
+++ b/src/server/command-executor.ts
@@ -708,10 +708,19 @@ export class CommandExecutor {
       (() => {
         const keywords = ${JSON.stringify(this.selectors.approveButton.textMatch ?? [])};
         const strategies = ${JSON.stringify(this.selectors.approveButton.strategies)};
+        const containerStrategies = ${JSON.stringify(this.selectors.chatContainer.strategies)};
+        let root = null;
+        for (const sel of containerStrategies) {
+          try {
+            root = document.querySelector(sel);
+            if (root) break;
+          } catch {}
+        }
+        if (!root) root = document.body;
 
         for (const selector of strategies) {
           try {
-            const buttons = document.querySelectorAll(selector);
+            const buttons = root.querySelectorAll(selector);
             for (const btn of Array.from(buttons)) {
               const text = (btn.textContent || '').trim().toLowerCase();
               if (text.includes('all')) {
@@ -723,7 +732,7 @@ export class CommandExecutor {
           } catch {}
         }
 
-        const allButtons = document.querySelectorAll('button');
+        const allButtons = root.querySelectorAll('button');
         for (const btn of Array.from(allButtons)) {
           const text = (btn.textContent || '').trim().toLowerCase();
           for (const kw of keywords) {

--- a/src/server/dom-extractor.ts
+++ b/src/server/dom-extractor.ts
@@ -1147,25 +1147,35 @@ export function extractionFunction(
       });
     }
 
-    // --- Approval buttons ---
+    // --- Approval buttons (must scope to this composer `container`; document-wide
+    //     queries pick up other agents' chats and sticky toolbars, so approvals
+    //     never clear after the active composer is approved in multi-agent mode.)
     const pendingApprovals: CursorState['pendingApprovals'] = [];
     const approveButtons: { label: string; selector: string }[] = [];
     const rejectButtons: { label: string; selector: string }[] = [];
+    const seenApproveBtns = new Set<Element>();
+    const seenRejectBtns = new Set<Element>();
 
     for (const sel of approveSelectors) {
       try {
-        const btns = document.querySelectorAll(sel);
+        const btns = container.querySelectorAll(sel);
         for (const btn of Array.from(btns)) {
+          if (seenApproveBtns.has(btn)) continue;
           const label = btn.textContent?.trim() || btn.getAttribute('aria-label') || '';
-          if (label) approveButtons.push({ label, selector: buildSelectorPath(btn) });
+          if (label) {
+            seenApproveBtns.add(btn);
+            approveButtons.push({ label, selector: buildSelectorPath(btn) });
+          }
         }
       } catch { /* skip */ }
     }
     if (approveButtons.length === 0 && approveTextMatch.length > 0) {
-      for (const btn of Array.from(document.querySelectorAll('button'))) {
+      for (const btn of Array.from(container.querySelectorAll('button'))) {
+        if (seenApproveBtns.has(btn)) continue;
         const text = `${btn.textContent?.trim() || ''} ${btn.getAttribute('aria-label') || ''}`.toLowerCase();
         for (const pat of approveTextMatch) {
           if (text.includes(pat.toLowerCase())) {
+            seenApproveBtns.add(btn);
             approveButtons.push({ label: btn.textContent?.trim() || pat, selector: buildSelectorPath(btn) });
             break;
           }
@@ -1175,18 +1185,24 @@ export function extractionFunction(
 
     for (const sel of rejectSelectors) {
       try {
-        const btns = document.querySelectorAll(sel);
+        const btns = container.querySelectorAll(sel);
         for (const btn of Array.from(btns)) {
+          if (seenRejectBtns.has(btn)) continue;
           const label = btn.textContent?.trim() || btn.getAttribute('aria-label') || '';
-          if (label) rejectButtons.push({ label, selector: buildSelectorPath(btn) });
+          if (label) {
+            seenRejectBtns.add(btn);
+            rejectButtons.push({ label, selector: buildSelectorPath(btn) });
+          }
         }
       } catch { /* skip */ }
     }
     if (rejectButtons.length === 0 && rejectTextMatch.length > 0) {
-      for (const btn of Array.from(document.querySelectorAll('button'))) {
+      for (const btn of Array.from(container.querySelectorAll('button'))) {
+        if (seenRejectBtns.has(btn)) continue;
         const text = `${btn.textContent?.trim() || ''} ${btn.getAttribute('aria-label') || ''}`.toLowerCase();
         for (const pat of rejectTextMatch) {
           if (text.includes(pat.toLowerCase())) {
+            seenRejectBtns.add(btn);
             rejectButtons.push({ label: btn.textContent?.trim() || pat, selector: buildSelectorPath(btn) });
             break;
           }


### PR DESCRIPTION
## Problem
`pendingApprovals` used `document.querySelectorAll` for global approve/reject selectors. With multiple agent composers, buttons from **other** chats (or the rest of the workbench) stay in the DOM, so the relay keeps reporting an approval after the active chat was approved.

## Change
- `dom-extractor`: collect approve/reject buttons only under the same `container` as chat messages (`chatContainer` strategies), with dedupe by element.
- `command-executor`: `findApproveAllButton` searches under the same chat root.

## Notes
Independent of multi-tab / glass sidebar work; cherry-picks cleanly onto upstream `main`.

Fixes / Refs https://github.com/len5ky/CursorRemote/issues/12

## Testing
`npm test`, `npm run build`