### PR TITLE
Add cursor-agent HTTP bridge controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,14 @@ TELEGRAM_BOT_TOKEN=
 # registration token (shown in server console) can /register themselves.
 # TELEGRAM_ALLOWED_USERS=123456789,987654321
 
+# === Cursor Agent HTTP Bridge (optional) ===
+# Enables token-protected helper endpoints for external tools:
+#   /execute, /execute_async, /jobs, /status, /emergency/clear-queue
+# Requests must include ?token=<this value>.
+# CURSOR_BRIDGE_TOKEN=change-me-long-random-token
+# CURSOR_AGENT_BIN=cursor-agent
+# CURSOR_AGENT_BASE_ARGS=--model auto --trust
+
 # === Extension Integration (optional) ===
 # These are set automatically when running as a VS Code extension child process.
 # You normally don't need to set them for standalone usage.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Download the latest `.vsix` from [releases](https://github.com/len5ky/CursorRemo
 
 ```bash
 # From the command line
-cursor --install-extension cursor-remote-0.1.45.vsix
+cursor --install-extension cursor-remote-0.1.46.vsix
 ```
 
 Or in Cursor: open the Command Palette (`Ctrl+Shift+P`), run **Extensions: Install from VSIX...**, and select the file.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Edit `.env` to configure the server. For Telegram, set `TELEGRAM_ENABLED=true` a
 | `CURSOR_BRIDGE_TOKEN` | -- | Enables token-protected `cursor-agent` HTTP bridge endpoints |
 | `CURSOR_AGENT_BIN` | `cursor-agent` | CLI binary used by the HTTP bridge |
 | `CURSOR_AGENT_BASE_ARGS` | `--model auto --trust` | Base args prepended to every bridge run |
+| `CURSOR_AGENT_ASYNC_TIMEOUT_MS` | `3600000` | Async bridge job timeout |
 | `LICENSE_KEY` | -- | License key via env (overrides file) |
 | `DATA_DIR` | `./data` | Data directory for persistent state |
 | `LOG_FORMAT` | `text` | Set to `json` for structured log lines |
@@ -208,6 +209,10 @@ curl "$BASE/execute?token=$TOKEN&cmd=-p%20%22Reply%20with%20READY%22"
 curl "$BASE/execute_async?token=$TOKEN&cmd=-p%20%22Long%20task%22"
 curl "$BASE/jobs?token=$TOKEN"
 ```
+
+Use `/execute` for short synchronous runs. Use `/execute_async` for longer work; it returns a job id and status URL. Poll `/jobs/j-XXXXXXXX?token=$TOKEN` to get `queued`, `running`, `done`, `error`, `timeout`, or `cancelled` plus accumulated stdout/stderr and offsets. For incremental polling, pass `since=<stdout byte offset>` and reuse the returned `stdout_offset`.
+
+Recent jobs are listed at `/jobs?token=$TOKEN&limit=20`; add `format=json` when a client can safely parse JSON. Cancel queued or running work with `/jobs/j-XXXXXXXX/cancel?token=$TOKEN`. The bridge runs one `cursor-agent` job at a time, queues extras, auto-cancels stale queued jobs after 30 minutes, and supersedes older queued jobs with identical args.
 
 For long or awkward argument strings, pass `b64=<base64 of cursor-agent args>` instead of `cmd`. If a job seems slow, check `/status`, then `/jobs`, then use `/emergency/clear-queue` or `/emergency/restart`.
 

--- a/README.md
+++ b/README.md
@@ -190,9 +190,26 @@ Edit `.env` to configure the server. For Telegram, set `TELEGRAM_ENABLED=true` a
 | `TELEGRAM_ENABLED` | `false` | Enable Telegram bot |
 | `TELEGRAM_BOT_TOKEN` | -- | Bot token from @BotFather |
 | `TELEGRAM_ALLOWED_USERS` | -- | Comma-separated allowed user IDs |
+| `CURSOR_BRIDGE_TOKEN` | -- | Enables token-protected `cursor-agent` HTTP bridge endpoints |
+| `CURSOR_AGENT_BIN` | `cursor-agent` | CLI binary used by the HTTP bridge |
+| `CURSOR_AGENT_BASE_ARGS` | `--model auto --trust` | Base args prepended to every bridge run |
 | `LICENSE_KEY` | -- | License key via env (overrides file) |
 | `DATA_DIR` | `./data` | Data directory for persistent state |
 | `LOG_FORMAT` | `text` | Set to `json` for structured log lines |
+
+### Cursor Agent HTTP Bridge
+
+Set `CURSOR_BRIDGE_TOKEN` to enable simple HTTP endpoints for external tools such as Grok:
+
+```bash
+BASE=http://127.0.0.1:3000
+TOKEN=your-long-random-token
+curl "$BASE/execute?token=$TOKEN&cmd=-p%20%22Reply%20with%20READY%22"
+curl "$BASE/execute_async?token=$TOKEN&cmd=-p%20%22Long%20task%22"
+curl "$BASE/jobs?token=$TOKEN"
+```
+
+For long or awkward argument strings, pass `b64=<base64 of cursor-agent args>` instead of `cmd`. If a job seems slow, check `/status`, then `/jobs`, then use `/emergency/clear-queue` or `/emergency/restart`.
 
 ### Production
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -46,7 +46,7 @@ The CursorRemote extension provides the easiest setup experience with built-in s
 Download the latest `.vsix` from [releases](https://github.com/len5ky/CursorRemote/releases) and install:
 
 ```bash
-cursor --install-extension cursor-remote-0.1.45.vsix
+cursor --install-extension cursor-remote-0.1.46.vsix
 ```
 
 Or in Cursor: Command Palette (`Ctrl+Shift+P`) > **Extensions: Install from VSIX...** > select the file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-remote",
-  "version": "0.1.41",
+  "version": "0.1.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-remote",
-      "version": "0.1.41",
+      "version": "0.1.45",
       "dependencies": {
         "@grammyjs/auto-retry": "^2.0.2",
         "dotenv": "^17.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cursor-remote",
   "displayName": "CursorRemote",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "description": "Remote control your local Cursor AI agent — monitor, approve, and send tasks from your phone or Telegram.",
   "publisher": "cursor-remote",
   "repository": {

--- a/src/server/cursor-agent-bridge.ts
+++ b/src/server/cursor-agent-bridge.ts
@@ -1,0 +1,395 @@
+import type express from 'express';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { randomBytes } from 'crypto';
+
+type JobStatus = 'queued' | 'running' | 'done' | 'error' | 'cancelled';
+
+interface BridgeJob {
+  id: string;
+  argsText: string;
+  args: string[];
+  status: JobStatus;
+  createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  error?: string;
+  process?: ChildProcessWithoutNullStreams;
+}
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+}
+
+const DEFAULT_SYNC_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_BUFFER_CHARS = 500_000;
+
+export class CursorAgentBridge {
+  private readonly token: string;
+  private readonly bin: string;
+  private readonly baseArgs: string[];
+  private jobs = new Map<string, BridgeJob>();
+  private queue: BridgeJob[] = [];
+  private runningJob: BridgeJob | null = null;
+
+  constructor() {
+    this.token =
+      process.env.CURSOR_BRIDGE_TOKEN
+      ?? process.env.GROK_BRIDGE_TOKEN
+      ?? process.env.EXECUTE_TOKEN
+      ?? process.env.TOKEN
+      ?? '';
+    this.bin = process.env.CURSOR_AGENT_BIN ?? 'cursor-agent';
+    this.baseArgs = parseShellWords(process.env.CURSOR_AGENT_BASE_ARGS ?? '--model auto --trust');
+  }
+
+  get enabled(): boolean {
+    return this.token.length > 0;
+  }
+
+  register(app: express.Application): void {
+    app.get('/status', (req, res) => {
+      if (!this.authorize(req, res)) return;
+      const state = this.statusPayload();
+      res.type('text').send(formatStatus(state));
+    });
+
+    app.get('/execute', async (req, res) => {
+      if (!this.authorize(req, res)) return;
+      let args: string[];
+      let argsText: string;
+      try {
+        ({ args, argsText } = this.parseArgsRequest(req));
+      } catch (err) {
+        return res.status(400).type('text').send(errorMessage(err));
+      }
+
+      try {
+        const result = await this.runCursorAgent(args, DEFAULT_SYNC_TIMEOUT_MS);
+        res
+          .status(result.exitCode === 0 && !result.timedOut ? 200 : 500)
+          .type('text')
+          .send(formatRunResult(argsText, result));
+      } catch (err) {
+        res.status(500).type('text').send(errorMessage(err));
+      }
+    });
+
+    app.get('/execute_async', (req, res) => {
+      if (!this.authorize(req, res)) return;
+      let args: string[];
+      let argsText: string;
+      try {
+        ({ args, argsText } = this.parseArgsRequest(req));
+      } catch (err) {
+        return res.status(400).type('text').send(errorMessage(err));
+      }
+
+      const job = this.createJob(argsText, args);
+      this.queue.push(job);
+      this.pumpQueue();
+      const base = `${req.protocol}://${req.get('host')}`;
+      res.type('text').send(
+        [
+          `Job ${job.id} submitted.`,
+          `status_url: ${base}/jobs/${job.id}?token=${encodeURIComponent(this.token)}`,
+          `$ ${this.renderCommand(args)}`,
+          `Remember the job id; tell the user "Submitted as ${job.id}. Ask me 'check that job' anytime."`,
+        ].join('\n')
+      );
+    });
+
+    app.get('/jobs', (req, res) => {
+      if (!this.authorize(req, res)) return;
+      const jobs = Array.from(this.jobs.values()).sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+      if (req.query.format === 'json') {
+        return res.json({ jobs: jobs.map(safeJob) });
+      }
+      res.type('text').send(formatJobList(jobs));
+    });
+
+    app.get('/jobs/:id', (req, res) => {
+      if (!this.authorize(req, res)) return;
+      const job = this.jobs.get(req.params.id);
+      if (!job) return res.status(404).type('text').send(`Job not found: ${req.params.id}`);
+      if (req.query.format === 'json') {
+        return res.json(safeJob(job));
+      }
+      res.type('text').send(formatJob(job));
+    });
+
+    app.get('/emergency/clear-queue', (req, res) => {
+      if (!this.authorize(req, res)) return;
+      const cleared = this.queue.splice(0);
+      for (const job of cleared) {
+        job.status = 'cancelled';
+        job.finishedAt = new Date().toISOString();
+        job.error = 'Cleared from queue by emergency/clear-queue';
+      }
+      res.type('text').send(`Cleared ${cleared.length} queued job(s). Running job: ${this.runningJob?.id ?? 'none'}`);
+    });
+
+    app.get('/emergency/restart', (req, res) => {
+      if (!this.authorize(req, res)) return;
+      const cleared = this.queue.splice(0);
+      for (const job of cleared) {
+        job.status = 'cancelled';
+        job.finishedAt = new Date().toISOString();
+        job.error = 'Cancelled by emergency/restart';
+      }
+      const killed = this.runningJob?.id ?? null;
+      if (this.runningJob?.process) {
+        this.runningJob.error = 'Killed by emergency/restart';
+        this.runningJob.process.kill('SIGTERM');
+      }
+      res.type('text').send(`Restarted bridge worker. Cancelled queued: ${cleared.length}. Killed running: ${killed ?? 'none'}`);
+    });
+
+    console.log(
+      this.enabled
+        ? '[cursor-agent-bridge] Enabled HTTP endpoints: /execute, /execute_async, /jobs'
+        : '[cursor-agent-bridge] Disabled; set CURSOR_BRIDGE_TOKEN to enable /execute endpoints'
+    );
+  }
+
+  private authorize(req: express.Request, res: express.Response): boolean {
+    if (!this.enabled) {
+      res.status(503).type('text').send('Cursor agent bridge disabled. Set CURSOR_BRIDGE_TOKEN.');
+      return false;
+    }
+    const supplied = typeof req.query.token === 'string' ? req.query.token : '';
+    if (supplied !== this.token) {
+      res.status(401).type('text').send('Unauthorized');
+      return false;
+    }
+    return true;
+  }
+
+  private parseArgsRequest(req: express.Request): { args: string[]; argsText: string } {
+    const cmd = typeof req.query.cmd === 'string' ? req.query.cmd : '';
+    const b64 = typeof req.query.b64 === 'string' ? req.query.b64 : '';
+    if (!cmd && !b64) throw new Error('Missing cmd or b64');
+    const argsText = b64 ? Buffer.from(b64, 'base64').toString('utf-8') : cmd;
+    const args = parseShellWords(argsText);
+    if (args.length === 0) throw new Error('No cursor-agent args parsed');
+    return { args, argsText };
+  }
+
+  private createJob(argsText: string, args: string[]): BridgeJob {
+    const id = `j-${randomBytes(4).toString('hex')}`;
+    const job: BridgeJob = {
+      id,
+      argsText,
+      args,
+      status: 'queued',
+      createdAt: new Date().toISOString(),
+      stdout: '',
+      stderr: '',
+    };
+    this.jobs.set(id, job);
+    return job;
+  }
+
+  private pumpQueue(): void {
+    if (this.runningJob || this.queue.length === 0) return;
+    const job = this.queue.shift()!;
+    this.runningJob = job;
+    job.status = 'running';
+    job.startedAt = new Date().toISOString();
+
+    const child = spawn(this.bin, [...this.baseArgs, ...job.args], {
+      env: process.env,
+      cwd: process.cwd(),
+    });
+    job.process = child;
+
+    child.stdout.on('data', chunk => {
+      job.stdout = appendBounded(job.stdout, chunk.toString());
+    });
+    child.stderr.on('data', chunk => {
+      job.stderr = appendBounded(job.stderr, chunk.toString());
+    });
+    child.on('error', err => {
+      job.status = 'error';
+      job.error = err.message;
+      job.finishedAt = new Date().toISOString();
+      this.runningJob = null;
+      this.pumpQueue();
+    });
+    child.on('close', (code, signal) => {
+      job.exitCode = code;
+      job.signal = signal;
+      if (job.status !== 'error' && job.status !== 'cancelled') {
+        job.status = code === 0 ? 'done' : 'error';
+      }
+      job.finishedAt = new Date().toISOString();
+      job.process = undefined;
+      this.runningJob = null;
+      this.pumpQueue();
+    });
+  }
+
+  private runCursorAgent(args: string[], timeoutMs: number): Promise<RunResult> {
+    return new Promise((resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
+      let timedOut = false;
+      const child = spawn(this.bin, [...this.baseArgs, ...args], {
+        env: process.env,
+        cwd: process.cwd(),
+      });
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+      }, timeoutMs);
+      timer.unref?.();
+
+      child.stdout.on('data', chunk => {
+        stdout = appendBounded(stdout, chunk.toString());
+      });
+      child.stderr.on('data', chunk => {
+        stderr = appendBounded(stderr, chunk.toString());
+      });
+      child.on('error', err => {
+        clearTimeout(timer);
+        reject(err);
+      });
+      child.on('close', (exitCode, signal) => {
+        clearTimeout(timer);
+        resolve({ stdout, stderr, exitCode, signal, timedOut });
+      });
+    });
+  }
+
+  private statusPayload(): { enabled: boolean; running: string | null; queued: number; jobs: number } {
+    return {
+      enabled: this.enabled,
+      running: this.runningJob?.id ?? null,
+      queued: this.queue.length,
+      jobs: this.jobs.size,
+    };
+  }
+
+  private renderCommand(args: string[]): string {
+    return [this.bin, ...this.baseArgs, ...args].map(shellQuote).join(' ');
+  }
+}
+
+export function parseShellWords(input: string): string[] {
+  const words: string[] = [];
+  let cur = '';
+  let quote: '"' | "'" | null = null;
+  let escaping = false;
+  let started = false;
+
+  for (const ch of input) {
+    if (escaping) {
+      cur += ch;
+      escaping = false;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && quote !== "'") {
+      escaping = true;
+      started = true;
+      continue;
+    }
+    if ((ch === '"' || ch === "'") && quote === null) {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === quote) {
+      quote = null;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch) && quote === null) {
+      if (started) {
+        words.push(cur);
+        cur = '';
+        started = false;
+      }
+      continue;
+    }
+    cur += ch;
+    started = true;
+  }
+
+  if (escaping) cur += '\\';
+  if (quote) throw new Error(`Unclosed ${quote} quote`);
+  if (started) words.push(cur);
+  return words;
+}
+
+function appendBounded(current: string, next: string): string {
+  const combined = current + next;
+  return combined.length > MAX_BUFFER_CHARS ? combined.slice(combined.length - MAX_BUFFER_CHARS) : combined;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function safeJob(job: BridgeJob): Omit<BridgeJob, 'process'> {
+  const { process: _process, ...safe } = job;
+  return safe;
+}
+
+function formatStatus(state: { enabled: boolean; running: string | null; queued: number; jobs: number }): string {
+  return [
+    'Cursor agent bridge status',
+    `enabled: ${state.enabled}`,
+    `running: ${state.running ?? 'none'}`,
+    `queued: ${state.queued}`,
+    `jobs: ${state.jobs}`,
+  ].join('\n');
+}
+
+function formatJobList(jobs: BridgeJob[]): string {
+  if (jobs.length === 0) return 'No jobs.';
+  return jobs.map(job => `${job.id}\t${job.status}\t${job.createdAt}\t${job.argsText}`).join('\n');
+}
+
+function formatJob(job: BridgeJob): string {
+  return [
+    `Job ${job.id}`,
+    `status: ${job.status}`,
+    `created_at: ${job.createdAt}`,
+    job.startedAt ? `started_at: ${job.startedAt}` : '',
+    job.finishedAt ? `finished_at: ${job.finishedAt}` : '',
+    job.exitCode !== undefined ? `exit_code: ${job.exitCode}` : '',
+    job.signal ? `signal: ${job.signal}` : '',
+    job.error ? `error: ${job.error}` : '',
+    `$ cursor-agent ${job.argsText}`,
+    '--- stdout ---',
+    job.stdout,
+    '--- stderr ---',
+    job.stderr,
+  ].filter(line => line !== '').join('\n');
+}
+
+function formatRunResult(argsText: string, result: RunResult): string {
+  return [
+    `$ cursor-agent ${argsText}`,
+    `exit_code: ${result.exitCode}`,
+    result.signal ? `signal: ${result.signal}` : '',
+    result.timedOut ? 'timed_out: true' : '',
+    '--- stdout ---',
+    result.stdout,
+    '--- stderr ---',
+    result.stderr,
+  ].filter(line => line !== '').join('\n');
+}
+
+function shellQuote(word: string): string {
+  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(word)) return word;
+  return `'${word.replace(/'/g, "'\\''")}'`;
+}

--- a/src/server/cursor-agent-bridge.ts
+++ b/src/server/cursor-agent-bridge.ts
@@ -2,7 +2,7 @@ import type express from 'express';
 import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import { randomBytes } from 'crypto';
 
-type JobStatus = 'queued' | 'running' | 'done' | 'error' | 'cancelled';
+type JobStatus = 'queued' | 'running' | 'done' | 'error' | 'timeout' | 'cancelled';
 
 interface BridgeJob {
   id: string;
@@ -29,12 +29,16 @@ interface RunResult {
 }
 
 const DEFAULT_SYNC_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_ASYNC_TIMEOUT_MS = 60 * 60 * 1000;
+const STALE_QUEUED_JOB_MS = 30 * 60 * 1000;
 const MAX_BUFFER_CHARS = 500_000;
+const MAX_LIST_LIMIT = 100;
 
 export class CursorAgentBridge {
   private readonly token: string;
   private readonly bin: string;
   private readonly baseArgs: string[];
+  private readonly asyncTimeoutMs: number;
   private jobs = new Map<string, BridgeJob>();
   private queue: BridgeJob[] = [];
   private runningJob: BridgeJob | null = null;
@@ -48,6 +52,7 @@ export class CursorAgentBridge {
       ?? '';
     this.bin = process.env.CURSOR_AGENT_BIN ?? 'cursor-agent';
     this.baseArgs = parseShellWords(process.env.CURSOR_AGENT_BASE_ARGS ?? '--model auto --trust');
+    this.asyncTimeoutMs = parsePositiveInt(process.env.CURSOR_AGENT_ASYNC_TIMEOUT_MS, DEFAULT_ASYNC_TIMEOUT_MS);
   }
 
   get enabled(): boolean {
@@ -93,22 +98,28 @@ export class CursorAgentBridge {
       }
 
       const job = this.createJob(argsText, args);
+      const superseded = this.supersedeQueuedDuplicates(job);
       this.queue.push(job);
       this.pumpQueue();
       const base = `${req.protocol}://${req.get('host')}`;
       res.type('text').send(
         [
           `Job ${job.id} submitted.`,
+          superseded > 0 ? `Superseded ${superseded} older queued duplicate job(s).` : '',
           `status_url: ${base}/jobs/${job.id}?token=${encodeURIComponent(this.token)}`,
           `$ ${this.renderCommand(args)}`,
           `Remember the job id; tell the user "Submitted as ${job.id}. Ask me 'check that job' anytime."`,
-        ].join('\n')
+        ].filter(Boolean).join('\n')
       );
     });
 
     app.get('/jobs', (req, res) => {
       if (!this.authorize(req, res)) return;
-      const jobs = Array.from(this.jobs.values()).sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+      this.cancelStaleQueuedJobs();
+      const limit = parseLimit(req.query.limit);
+      const jobs = Array.from(this.jobs.values())
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+        .slice(0, limit);
       if (req.query.format === 'json') {
         return res.json({ jobs: jobs.map(safeJob) });
       }
@@ -117,12 +128,26 @@ export class CursorAgentBridge {
 
     app.get('/jobs/:id', (req, res) => {
       if (!this.authorize(req, res)) return;
+      this.cancelStaleQueuedJobs();
       const job = this.jobs.get(req.params.id);
       if (!job) return res.status(404).type('text').send(`Job not found: ${req.params.id}`);
       if (req.query.format === 'json') {
-        return res.json(safeJob(job));
+        return res.json(sliceSafeJob(job, parseSince(req.query.since)));
       }
-      res.type('text').send(formatJob(job));
+      res.type('text').send(formatJob(job, parseSince(req.query.since)));
+    });
+
+    app.get('/jobs/:id/cancel', (req, res) => {
+      if (!this.authorize(req, res)) return;
+      this.cancelStaleQueuedJobs();
+      const job = this.jobs.get(req.params.id);
+      if (!job) return res.status(404).type('text').send(`Job not found: ${req.params.id}`);
+      const cancelled = this.cancelJob(job, 'Cancelled by /jobs/:id/cancel');
+      res.type('text').send(
+        cancelled
+          ? `Cancelled ${job.id}.`
+          : `Job ${job.id} is already ${job.status}.`
+      );
     });
 
     app.get('/emergency/clear-queue', (req, res) => {
@@ -197,7 +222,55 @@ export class CursorAgentBridge {
     return job;
   }
 
+  private supersedeQueuedDuplicates(newJob: BridgeJob): number {
+    let superseded = 0;
+    this.queue = this.queue.filter(job => {
+      if (job.status === 'queued' && sameArgs(job.args, newJob.args)) {
+        job.status = 'cancelled';
+        job.finishedAt = new Date().toISOString();
+        job.error = `Superseded by duplicate job ${newJob.id}`;
+        superseded += 1;
+        return false;
+      }
+      return true;
+    });
+    return superseded;
+  }
+
+  private cancelStaleQueuedJobs(): void {
+    const now = Date.now();
+    this.queue = this.queue.filter(job => {
+      const createdAt = Date.parse(job.createdAt);
+      if (Number.isFinite(createdAt) && now - createdAt > STALE_QUEUED_JOB_MS) {
+        job.status = 'cancelled';
+        job.finishedAt = new Date().toISOString();
+        job.error = 'Auto-cancelled after 30 minutes in queue';
+        return false;
+      }
+      return true;
+    });
+  }
+
+  private cancelJob(job: BridgeJob, reason: string): boolean {
+    if (job.status === 'queued') {
+      this.queue = this.queue.filter(queued => queued.id !== job.id);
+      job.status = 'cancelled';
+      job.finishedAt = new Date().toISOString();
+      job.error = reason;
+      return true;
+    }
+    if (job.status === 'running' && job.process) {
+      job.status = 'cancelled';
+      job.finishedAt = new Date().toISOString();
+      job.error = reason;
+      job.process.kill('SIGTERM');
+      return true;
+    }
+    return false;
+  }
+
   private pumpQueue(): void {
+    this.cancelStaleQueuedJobs();
     if (this.runningJob || this.queue.length === 0) return;
     const job = this.queue.shift()!;
     this.runningJob = job;
@@ -209,6 +282,14 @@ export class CursorAgentBridge {
       cwd: process.cwd(),
     });
     job.process = child;
+    const timer = setTimeout(() => {
+      if (job.status === 'running') {
+        job.status = 'timeout';
+        job.error = `Timed out after ${this.asyncTimeoutMs}ms`;
+        child.kill('SIGTERM');
+      }
+    }, this.asyncTimeoutMs);
+    timer.unref?.();
 
     child.stdout.on('data', chunk => {
       job.stdout = appendBounded(job.stdout, chunk.toString());
@@ -217,6 +298,7 @@ export class CursorAgentBridge {
       job.stderr = appendBounded(job.stderr, chunk.toString());
     });
     child.on('error', err => {
+      clearTimeout(timer);
       job.status = 'error';
       job.error = err.message;
       job.finishedAt = new Date().toISOString();
@@ -224,9 +306,10 @@ export class CursorAgentBridge {
       this.pumpQueue();
     });
     child.on('close', (code, signal) => {
+      clearTimeout(timer);
       job.exitCode = code;
       job.signal = signal;
-      if (job.status !== 'error' && job.status !== 'cancelled') {
+      if (job.status !== 'error' && job.status !== 'cancelled' && job.status !== 'timeout') {
         job.status = code === 0 ? 'done' : 'error';
       }
       job.finishedAt = new Date().toISOString();
@@ -343,6 +426,17 @@ function safeJob(job: BridgeJob): Omit<BridgeJob, 'process'> {
   return safe;
 }
 
+function sliceSafeJob(job: BridgeJob, since: number): Omit<BridgeJob, 'process'> & { stdoutOffset: number; stderrOffset: number } {
+  const safe = safeJob(job);
+  return {
+    ...safe,
+    stdout: sliceUtf8ByByteOffset(job.stdout, since),
+    stderr: sliceUtf8ByByteOffset(job.stderr, since),
+    stdoutOffset: Buffer.byteLength(job.stdout),
+    stderrOffset: Buffer.byteLength(job.stderr),
+  };
+}
+
 function formatStatus(state: { enabled: boolean; running: string | null; queued: number; jobs: number }): string {
   return [
     'Cursor agent bridge status',
@@ -358,7 +452,9 @@ function formatJobList(jobs: BridgeJob[]): string {
   return jobs.map(job => `${job.id}\t${job.status}\t${job.createdAt}\t${job.argsText}`).join('\n');
 }
 
-function formatJob(job: BridgeJob): string {
+function formatJob(job: BridgeJob, since = 0): string {
+  const stdoutOffset = Buffer.byteLength(job.stdout);
+  const stderrOffset = Buffer.byteLength(job.stderr);
   return [
     `Job ${job.id}`,
     `status: ${job.status}`,
@@ -368,11 +464,13 @@ function formatJob(job: BridgeJob): string {
     job.exitCode !== undefined ? `exit_code: ${job.exitCode}` : '',
     job.signal ? `signal: ${job.signal}` : '',
     job.error ? `error: ${job.error}` : '',
+    `stdout_offset: ${stdoutOffset}`,
+    `stderr_offset: ${stderrOffset}`,
     `$ cursor-agent ${job.argsText}`,
     '--- stdout ---',
-    job.stdout,
+    sliceUtf8ByByteOffset(job.stdout, since),
     '--- stderr ---',
-    job.stderr,
+    sliceUtf8ByByteOffset(job.stderr, since),
   ].filter(line => line !== '').join('\n');
 }
 
@@ -392,4 +490,32 @@ function formatRunResult(argsText: string, result: RunResult): string {
 function shellQuote(word: string): string {
   if (/^[A-Za-z0-9_./:=@%+-]+$/.test(word)) return word;
   return `'${word.replace(/'/g, "'\\''")}'`;
+}
+
+function sameArgs(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseLimit(value: unknown): number {
+  if (typeof value !== 'string') return 20;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 20;
+  return Math.min(parsed, MAX_LIST_LIMIT);
+}
+
+function parseSince(value: unknown): number {
+  if (typeof value !== 'string') return 0;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function sliceUtf8ByByteOffset(value: string, since: number): string {
+  if (since <= 0) return value;
+  return Buffer.from(value, 'utf-8').slice(since).toString('utf-8');
 }

--- a/src/server/dedup.ts
+++ b/src/server/dedup.ts
@@ -1,0 +1,160 @@
+/**
+ * Lightweight in-memory deduplication for socket command requests.
+ *
+ * Problem: Grok (and some other clients) frequently fire the same request
+ * multiple times in rapid succession — e.g. sending the identical
+ * "send_message" prompt twice within a few seconds.  Without dedup this
+ * causes the same text to be typed into Cursor twice, creating duplicate
+ * agent runs and confusing the UI state.
+ *
+ * Design
+ * ──────
+ * Each in-flight or recently-completed command is indexed by a **fingerprint**
+ * derived from two stable fields:
+ *
+ *   fingerprint = "<socketEvent>|<normalizedText>"
+ *
+ * where `normalizedText` is the command text lowercased and whitespace-
+ * collapsed, so minor formatting differences don't break dedup.
+ *
+ * When a duplicate arrives we return one of two canned responses:
+ *   • still running  → { dedupStatus: "running",  jobId }
+ *   • already done   → { dedupStatus: "completed", jobId, result }
+ *
+ * The cache entry expires after DEDUP_TTL_MS (default 30 s) to prevent
+ * stale entries from blocking legitimate re-sends.
+ */
+
+export type DedupStatus = 'running' | 'completed';
+
+export interface DedupEntry {
+  jobId: string;
+  fingerprint: string;
+  status: DedupStatus;
+  /** ISO timestamp when the entry was created */
+  startedAt: string;
+  /** Populated once the command finishes */
+  result?: unknown;
+  /** When the entry should be evicted (ms since epoch) */
+  expiresAt: number;
+}
+
+/** How long to keep a completed-job entry before allowing a re-run (ms). */
+const DEDUP_TTL_MS = 30_000;
+
+/** How often the background sweep removes expired entries (ms). */
+const SWEEP_INTERVAL_MS = 60_000;
+
+let _jobCounter = 0;
+function nextJobId(): string {
+  return `job-${++_jobCounter}-${Date.now().toString(36)}`;
+}
+
+/**
+ * Normalize a command string into a stable, comparison-safe key.
+ * Collapses all whitespace and lower-cases so minor formatting differences
+ * (extra spaces, mixed case) don't create false negatives.
+ */
+export function normalizeCommand(text: string): string {
+  return text.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/**
+ * Build the fingerprint key from the socket event name and command body.
+ * The event name acts as the "endpoint" discriminator so that
+ * `send_message("foo")` and `approve("foo")` are never conflated.
+ */
+export function makeFingerprint(eventName: string, normalizedText: string): string {
+  return `${eventName}|${normalizedText}`;
+}
+
+export class DedupCache {
+  private cache = new Map<string, DedupEntry>();
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    // Periodically evict stale entries so the map doesn't grow unbounded.
+    this.sweepTimer = setInterval(() => this.sweep(), SWEEP_INTERVAL_MS);
+    // Don't let the timer prevent Node from exiting.
+    this.sweepTimer.unref?.();
+  }
+
+  /**
+   * Check whether a fingerprint is already known.
+   *
+   * Returns `null` if this is a new request (caller should proceed normally),
+   * or a `DedupEntry` if it's a duplicate (caller should short-circuit).
+   */
+  lookup(fingerprint: string): DedupEntry | null {
+    const entry = this.cache.get(fingerprint);
+    if (!entry) return null;
+
+    // Evict if the TTL has passed — treat as a fresh request.
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(fingerprint);
+      return null;
+    }
+
+    return entry;
+  }
+
+  /**
+   * Register a new in-flight job.  Call this immediately before dispatching
+   * the real command so that concurrent duplicates are blocked.
+   */
+  register(fingerprint: string): DedupEntry {
+    const entry: DedupEntry = {
+      jobId: nextJobId(),
+      fingerprint,
+      status: 'running',
+      startedAt: new Date().toISOString(),
+      expiresAt: Date.now() + DEDUP_TTL_MS,
+    };
+    this.cache.set(fingerprint, entry);
+    return entry;
+  }
+
+  /**
+   * Mark a job as completed and store its result.
+   * The TTL is reset from *now* so callers that arrive shortly after
+   * completion still get the cached result.
+   */
+  complete(fingerprint: string, result: unknown): void {
+    const entry = this.cache.get(fingerprint);
+    if (!entry) return;
+    entry.status = 'completed';
+    entry.result = result;
+    entry.expiresAt = Date.now() + DEDUP_TTL_MS;
+  }
+
+  /**
+   * Remove a job entry immediately (e.g. on error, so the next attempt isn't
+   * blocked by a stale "running" entry).
+   */
+  evict(fingerprint: string): void {
+    this.cache.delete(fingerprint);
+  }
+
+  /** Evict all entries whose TTL has elapsed. */
+  private sweep(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.cache) {
+      if (now > entry.expiresAt) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  /** Size of the current cache (for diagnostics). */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  destroy(): void {
+    if (this.sweepTimer !== null) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    this.cache.clear();
+  }
+}

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -430,16 +430,26 @@ export class Relay {
         }
 
         this.commandDedup.register(fingerprint);
-        const result = await this.commandExecutor.sendMessage(
-          payload.commandId,
-          payload.text
-        );
-        if (result.ok) {
-          this.commandDedup.complete(fingerprint, result);
-        } else {
+        try {
+          const result = await this.commandExecutor.sendMessage(
+            payload.commandId,
+            payload.text
+          );
+          if (result.ok) {
+            this.commandDedup.complete(fingerprint, result);
+          } else {
+            this.commandDedup.evict(fingerprint);
+          }
+          socket.emit('command:result', result);
+        } catch (err) {
           this.commandDedup.evict(fingerprint);
+          const msg = err instanceof Error ? err.message : String(err);
+          socket.emit('command:result', {
+            commandId: payload.commandId,
+            ok: false,
+            error: msg,
+          } satisfies CommandResult);
         }
-        socket.emit('command:result', result);
       });
 
       socket.on('command:approve', async (payload: CommandPayload) => {

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -11,6 +11,7 @@ import type { CommandExecutor } from './command-executor.js';
 import type { CDPBridge } from './cdp-bridge.js';
 import { markdownToWebHtml, readPlanFile } from './plan-files.js';
 import { CursorAgentBridge } from './cursor-agent-bridge.js';
+import { DedupCache, makeFingerprint, normalizeCommand } from './dedup.js';
 import {
   WEBAPP_SESSION_COOKIE,
   createWebappSessionStore,
@@ -117,6 +118,7 @@ export class Relay {
   private commandExecutor: CommandExecutor;
   private cdpBridge: CDPBridge;
   private cursorAgentBridge: CursorAgentBridge;
+  private commandDedup = new DedupCache();
 
   private sessionStore: WebappSessionStore;
   private loginAttempts = new Map<string, RateLimitEntry>();
@@ -173,6 +175,7 @@ export class Relay {
   }
 
   async stop(): Promise<void> {
+    this.commandDedup.destroy();
     this.io.close();
     return new Promise((resolve) => {
       this.httpServer.close(() => resolve());
@@ -408,10 +411,34 @@ export class Relay {
           return;
         }
         console.log(`[relay] Command: send_message from ${socket.id}`);
+        const fingerprint = makeFingerprint(
+          'command:send_message',
+          normalizeCommand(payload.text)
+        );
+        const duplicate = this.commandDedup.lookup(fingerprint);
+        if (duplicate) {
+          socket.emit('command:result', {
+            commandId: payload.commandId,
+            ok: true,
+            data: {
+              dedupStatus: duplicate.status,
+              jobId: duplicate.jobId,
+              ...(duplicate.status === 'completed' ? { result: duplicate.result } : {}),
+            },
+          } satisfies CommandResult);
+          return;
+        }
+
+        this.commandDedup.register(fingerprint);
         const result = await this.commandExecutor.sendMessage(
           payload.commandId,
           payload.text
         );
+        if (result.ok) {
+          this.commandDedup.complete(fingerprint, result);
+        } else {
+          this.commandDedup.evict(fingerprint);
+        }
         socket.emit('command:result', result);
       });
 

--- a/src/server/relay.ts
+++ b/src/server/relay.ts
@@ -10,6 +10,7 @@ import type { StateManager } from './state-manager.js';
 import type { CommandExecutor } from './command-executor.js';
 import type { CDPBridge } from './cdp-bridge.js';
 import { markdownToWebHtml, readPlanFile } from './plan-files.js';
+import { CursorAgentBridge } from './cursor-agent-bridge.js';
 import {
   WEBAPP_SESSION_COOKIE,
   createWebappSessionStore,
@@ -115,6 +116,7 @@ export class Relay {
   private stateManager: StateManager;
   private commandExecutor: CommandExecutor;
   private cdpBridge: CDPBridge;
+  private cursorAgentBridge: CursorAgentBridge;
 
   private sessionStore: WebappSessionStore;
   private loginAttempts = new Map<string, RateLimitEntry>();
@@ -137,6 +139,7 @@ export class Relay {
     this.commandExecutor = commandExecutor;
     this.cdpBridge = cdpBridge;
     this.sessionStore = createWebappSessionStore(config.dataDir);
+    this.cursorAgentBridge = new CursorAgentBridge();
 
     this.app = express();
     this.httpServer = createServer(this.app);
@@ -231,6 +234,7 @@ export class Relay {
     const clientDir = join(__dirname, '..', 'client');
 
     this.app.use(express.json());
+    this.cursorAgentBridge.register(this.app);
 
     this.app.get('/login', (_req, res) => {
       if (!this.authEnabled) return res.redirect('/');

--- a/tests/cursor-agent-bridge.test.ts
+++ b/tests/cursor-agent-bridge.test.ts
@@ -1,0 +1,21 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseShellWords } from '../src/server/cursor-agent-bridge.js';
+
+describe('cursor-agent bridge shell arg parsing', () => {
+  it('parses quoted prompts as one argument', () => {
+    assert.deepEqual(parseShellWords('-p "Reply with READY"'), ['-p', 'Reply with READY']);
+  });
+
+  it('supports single quotes and escaped spaces', () => {
+    assert.deepEqual(parseShellWords("--flag 'one two' three\\ four"), ['--flag', 'one two', 'three four']);
+  });
+
+  it('preserves empty quoted arguments', () => {
+    assert.deepEqual(parseShellWords('-p ""'), ['-p', '']);
+  });
+
+  it('rejects unclosed quotes', () => {
+    assert.throws(() => parseShellWords('-p "unfinished'), /Unclosed/);
+  });
+});

--- a/tests/cursor-agent-bridge.test.ts
+++ b/tests/cursor-agent-bridge.test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseShellWords } from '../src/server/cursor-agent-bridge.js';
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express from 'express';
+import { CursorAgentBridge, parseShellWords } from '../src/server/cursor-agent-bridge.js';
 
 describe('cursor-agent bridge shell arg parsing', () => {
   it('parses quoted prompts as one argument', () => {
@@ -19,3 +23,119 @@ describe('cursor-agent bridge shell arg parsing', () => {
     assert.throws(() => parseShellWords('-p "unfinished'), /Unclosed/);
   });
 });
+
+describe('cursor-agent bridge HTTP endpoints', () => {
+  it('supports async polling, since offsets, duplicate supersede, and cancel', async () => {
+    const oldToken = process.env.CURSOR_BRIDGE_TOKEN;
+    const oldBin = process.env.CURSOR_AGENT_BIN;
+    const oldBaseArgs = process.env.CURSOR_AGENT_BASE_ARGS;
+    const oldTimeout = process.env.CURSOR_AGENT_ASYNC_TIMEOUT_MS;
+    const bin = createFakeCursorAgentBin();
+
+    process.env.CURSOR_BRIDGE_TOKEN = 'test-token';
+    process.env.CURSOR_AGENT_BIN = bin;
+    process.env.CURSOR_AGENT_BASE_ARGS = '';
+    process.env.CURSOR_AGENT_ASYNC_TIMEOUT_MS = '2000';
+
+    const app = express();
+    const bridge = new CursorAgentBridge();
+    bridge.register(app);
+    const server = app.listen(0);
+
+    try {
+      const address = server.address();
+      assert.equal(typeof address, 'object');
+      assert(address);
+      const base = `http://127.0.0.1:${address.port}`;
+
+      const completed = await submit(base, 'test-token', '--echo abcdef');
+      await waitForStatus(base, 'test-token', completed, 'done');
+      const incremental = await textFetch(`${base}/jobs/${completed}?token=test-token&since=3`);
+      const incrementalStdout = incremental.split('--- stdout ---\n')[1]?.split('\n--- stderr ---')[0] ?? '';
+      assert.match(incremental, /stdout_offset: 7/);
+      assert.match(incrementalStdout, /def/);
+      assert.doesNotMatch(incrementalStdout, /abcdef/);
+
+      const blocker = await submit(base, 'test-token', '--sleep');
+      await waitForStatus(base, 'test-token', blocker, 'running');
+
+      const duplicateA = await submit(base, 'test-token', '--echo duplicate');
+      const duplicateBResponse = await textFetch(`${base}/execute_async?token=test-token&cmd=${encodeURIComponent('--echo duplicate')}`);
+      const duplicateB = extractJobId(duplicateBResponse);
+      assert.match(duplicateBResponse, /Superseded 1 older queued duplicate job/);
+
+      const oldDuplicate = await textFetch(`${base}/jobs/${duplicateA}?token=test-token`);
+      assert.match(oldDuplicate, /status: cancelled/);
+      assert.match(oldDuplicate, new RegExp(`Superseded by duplicate job ${duplicateB}`));
+
+      const cancelResponse = await textFetch(`${base}/jobs/${blocker}/cancel?token=test-token`);
+      assert.match(cancelResponse, new RegExp(`Cancelled ${blocker}`));
+      await waitForStatus(base, 'test-token', blocker, 'cancelled');
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      restoreEnv('CURSOR_BRIDGE_TOKEN', oldToken);
+      restoreEnv('CURSOR_AGENT_BIN', oldBin);
+      restoreEnv('CURSOR_AGENT_BASE_ARGS', oldBaseArgs);
+      restoreEnv('CURSOR_AGENT_ASYNC_TIMEOUT_MS', oldTimeout);
+    }
+  });
+});
+
+function createFakeCursorAgentBin(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'cursor-agent-bridge-'));
+  const bin = join(dir, 'cursor-agent');
+  writeFileSync(
+    bin,
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "--sleep" ]; then',
+      '  sleep 20',
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "--echo" ]; then',
+      '  printf "%s\\n" "$2"',
+      '  exit 0',
+      'fi',
+      'printf "%s\\n" "$*"',
+    ].join('\n')
+  );
+  chmodSync(bin, 0o755);
+  return bin;
+}
+
+async function submit(base: string, token: string, cmd: string): Promise<string> {
+  const response = await textFetch(`${base}/execute_async?token=${token}&cmd=${encodeURIComponent(cmd)}`);
+  return extractJobId(response);
+}
+
+function extractJobId(response: string): string {
+  const match = response.match(/Job (j-[0-9a-f]+) submitted/);
+  assert(match, response);
+  return match[1];
+}
+
+async function waitForStatus(base: string, token: string, jobId: string, status: string): Promise<string> {
+  const deadline = Date.now() + 3000;
+  let body = '';
+  while (Date.now() < deadline) {
+    body = await textFetch(`${base}/jobs/${jobId}?token=${token}`);
+    if (body.includes(`status: ${status}`)) return body;
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  assert.fail(`Timed out waiting for ${jobId} to be ${status}. Last body:\n${body}`);
+}
+
+async function textFetch(url: string): Promise<string> {
+  const response = await fetch(url);
+  const body = await response.text();
+  assert(response.ok, body);
+  return body;
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/tests/dedup.test.ts
+++ b/tests/dedup.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { DedupCache, makeFingerprint, normalizeCommand } from '../src/server/dedup.js';
+
+describe('command deduplication', () => {
+  it('normalizes command text and scopes fingerprints by event', () => {
+    assert.equal(normalizeCommand('  Send   THIS\nnow  '), 'send this now');
+    assert.equal(
+      makeFingerprint('command:send_message', normalizeCommand('Hello')),
+      'command:send_message|hello'
+    );
+    assert.notEqual(
+      makeFingerprint('command:send_message', normalizeCommand('Hello')),
+      makeFingerprint('command:approve', normalizeCommand('Hello'))
+    );
+  });
+
+  it('returns running and completed entries for duplicate fingerprints', () => {
+    const cache = new DedupCache();
+    try {
+      const fingerprint = makeFingerprint('command:send_message', normalizeCommand('Fix it'));
+      assert.equal(cache.lookup(fingerprint), null);
+
+      const registered = cache.register(fingerprint);
+      const running = cache.lookup(fingerprint);
+      assert.equal(running?.jobId, registered.jobId);
+      assert.equal(running?.status, 'running');
+
+      const result = { commandId: 'cmd-1', ok: true };
+      cache.complete(fingerprint, result);
+      const completed = cache.lookup(fingerprint);
+      assert.equal(completed?.jobId, registered.jobId);
+      assert.equal(completed?.status, 'completed');
+      assert.deepEqual(completed?.result, result);
+    } finally {
+      cache.destroy();
+    }
+  });
+
+  it('evicts failed or retryable fingerprints', () => {
+    const cache = new DedupCache();
+    try {
+      const fingerprint = makeFingerprint('command:send_message', normalizeCommand('Retry me'));
+      cache.register(fingerprint);
+      cache.evict(fingerprint);
+      assert.equal(cache.lookup(fingerprint), null);
+      assert.equal(cache.size, 0);
+    } finally {
+      cache.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add token-protected cursor-agent HTTP bridge endpoints for /execute, /execute_async, /jobs, cancellation, and emergency queue controls
- document bridge environment variables and usage patterns
- package verified release build as v0.1.46

## Verification
- npm test
- npm run compile --if-present
- npm run lint --if-present
- npm run package --if-present

## Notes
- Local push to upstream origin was denied for ekulkisnek, so the branch is pushed to ekulkisnek/CursorRemote and opened against len5ky/CursorRemote.