### PR TITLE
Fix message extraction for Cursor 3.8 virtualized chat DOM.

### DIFF
--- a/scripts/probe-cdp.ts
+++ b/scripts/probe-cdp.ts
@@ -58,7 +58,7 @@ async function main() {
     // All .make-shine elements
     const shineEls = container.querySelectorAll('.make-shine');
     for (const el of Array.from(shineEls)) {
-      const wrapper = el.closest('[data-flat-index]');
+      const wrapper = el.closest('[data-message-index], [data-flat-index]');
       const toolCall = el.closest('[data-tool-call-id]');
       const header = el.closest('.ui-collapsible-header');
       const loadingInd = el.closest('.loading-indicator-v3') || wrapper?.querySelector('.loading-indicator-v3');
@@ -66,7 +66,7 @@ async function main() {
         type: 'make-shine',
         text: (el.textContent || '').trim().substring(0, 200),
         parentText: (el.parentElement?.textContent || '').trim().substring(0, 200),
-        wrapperFlatIndex: wrapper?.getAttribute('data-flat-index'),
+        wrapperFlatIndex: wrapper?.getAttribute('data-message-index') || wrapper?.getAttribute('data-flat-index'),
         insideToolCall: !!toolCall,
         toolCallId: toolCall?.getAttribute('data-tool-call-id'),
         insideHeader: !!header,
@@ -79,12 +79,12 @@ async function main() {
     // Loading indicators
     const loadingEls = container.querySelectorAll('.loading-indicator-v3');
     for (const el of Array.from(loadingEls)) {
-      const wrapper = el.closest('[data-flat-index]');
+      const wrapper = el.closest('[data-message-index], [data-flat-index]');
       out.push({
         type: 'loading-indicator',
         text: (el.textContent || '').trim().substring(0, 200),
         wrapperText: (wrapper?.textContent || '').trim().substring(0, 200),
-        wrapperFlatIndex: wrapper?.getAttribute('data-flat-index'),
+        wrapperFlatIndex: wrapper?.getAttribute('data-message-index') || wrapper?.getAttribute('data-flat-index'),
         classes: el.className,
         wrapperClasses: wrapper?.className || '',
       });
@@ -94,12 +94,12 @@ async function main() {
     const thinkingCollapsibles = container.querySelectorAll('.ui-collapsible.ui-thinking-collapsible');
     for (const tc of Array.from(thinkingCollapsibles).slice(0, 15)) {
       const hdr = tc.querySelector('.ui-collapsible-header');
-      const wrapper = tc.closest('[data-flat-index]');
+      const wrapper = tc.closest('[data-message-index], [data-flat-index]');
       out.push({
         type: 'ui-thinking-collapsible',
         headerText: (hdr?.textContent || '').replace(/\s+/g, ' ').trim().substring(0, 200),
         hasMakeShine: !!tc.querySelector('.make-shine') || !!hdr?.querySelector('.make-shine'),
-        wrapperFlatIndex: wrapper?.getAttribute('data-flat-index'),
+        wrapperFlatIndex: wrapper?.getAttribute('data-message-index') || wrapper?.getAttribute('data-flat-index'),
         dataOpen: tc.getAttribute('data-open'),
         dataExpandable: tc.getAttribute('data-expandable'),
       });
@@ -110,7 +110,7 @@ async function main() {
     for (const sg of Array.from(stepGroups)) {
       const header = sg.querySelector('.ui-collapsible-header');
       if (!header) continue;
-      const wrapper = sg.closest('[data-flat-index]');
+      const wrapper = sg.closest('[data-message-index], [data-flat-index]');
       const allChildren = header.querySelectorAll('*');
       const animatedClasses: string[] = [];
       for (const child of Array.from(allChildren)) {
@@ -125,7 +125,7 @@ async function main() {
         type: 'step-group-header',
         text: (header.textContent || '').trim().substring(0, 200),
         headerClasses: hEl.className,
-        wrapperFlatIndex: wrapper?.getAttribute('data-flat-index'),
+        wrapperFlatIndex: wrapper?.getAttribute('data-message-index') || wrapper?.getAttribute('data-flat-index'),
         childClasses: animatedClasses.slice(0, 20),
         animation: computed.animation || computed.getPropertyValue('animation'),
         transition: computed.transition,
@@ -135,10 +135,10 @@ async function main() {
     }
 
     // Last [data-flat-index] element — often the most interesting (tail of chat)
-    const allFlatIdx = container.querySelectorAll('[data-flat-index]');
+    const allFlatIdx = container.querySelectorAll('[data-message-index], [data-flat-index]');
     if (allFlatIdx.length > 0) {
       const lastWrapper = allFlatIdx[allFlatIdx.length - 1] as HTMLElement;
-      const fi = lastWrapper.getAttribute('data-flat-index');
+      const fi = lastWrapper.getAttribute('data-message-index') || lastWrapper.getAttribute('data-flat-index');
       const role = lastWrapper.getAttribute('data-tab0-role');
       const kind = lastWrapper.getAttribute('data-tab0-kind');
       const stepGroup = lastWrapper.querySelector('.ui-collapsible.ui-step-group-collapsible');
@@ -165,13 +165,13 @@ async function main() {
       try {
         const els = container.querySelectorAll(sel);
         for (const el of Array.from(els).slice(0, 5)) {
-          const wrapper = el.closest('[data-flat-index]');
+          const wrapper = el.closest('[data-message-index], [data-flat-index]');
           out.push({
             type: 'shimmer-pattern',
             selector: sel,
             text: (el.textContent || '').trim().substring(0, 100),
             classes: el.className.substring(0, 200),
-            wrapperFlatIndex: wrapper?.getAttribute('data-flat-index'),
+            wrapperFlatIndex: wrapper?.getAttribute('data-message-index') || wrapper?.getAttribute('data-flat-index'),
             tag: el.tagName,
           });
         }

--- a/src/discovery/capture-thinking.ts
+++ b/src/discovery/capture-thinking.ts
@@ -64,7 +64,7 @@ async function main(): Promise<void> {
       const result = await client.evaluate(`
         (() => {
           const out = [];
-          const wrappers = document.querySelectorAll('[data-flat-index]');
+          const wrappers = document.querySelectorAll('[data-message-index], [data-flat-index]');
           for (const w of wrappers) {
             const hasLoading = !!w.querySelector('.loading-indicator-v3');
             const hasStepGroup = !!w.querySelector('.ui-collapsible.ui-step-group-collapsible');
@@ -79,7 +79,7 @@ async function main(): Promise<void> {
             const preview = w.querySelector('.ui-step-group-preview');
 
             out.push({
-              flatIndex: parseInt(w.getAttribute('data-flat-index') || '0', 10),
+              flatIndex: parseInt(w.getAttribute('data-message-index') || w.getAttribute('data-flat-index') || '0', 10),
               hasLoading,
               hasStepGroup,
               hasThinkingCollapsible: hasThinking,

--- a/src/server/command-executor.ts
+++ b/src/server/command-executor.ts
@@ -5,6 +5,9 @@ const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 500;
 const FOCUS_DELAY_MS = 100;
 
+// Cursor 3.8+ uses data-message-index; older builds use data-flat-index.
+const MESSAGE_WRAPPER_SELECTOR = '[data-message-index], [data-flat-index]';
+
 // Resolves the currently-open model picker menu element across Cursor versions.
 // Older builds expose `[data-testid="model-picker-menu"]`; newer builds (~3.5.17)
 // removed the testid and render the picker as a generic `[role="menu"]` opened
@@ -457,10 +460,11 @@ export class CommandExecutor {
     const result = await this.client.evaluate(`
       (() => {
         const tcId = ${JSON.stringify(toolCallId)};
+        const wrapperSel = ${JSON.stringify(MESSAGE_WRAPPER_SELECTOR)};
         const wrapper = document.querySelector('[data-tool-call-id="' + tcId + '"]')
-          || document.querySelector('[data-tool-call-id="' + tcId + '"]')?.closest('[data-flat-index]')
+          || document.querySelector('[data-tool-call-id="' + tcId + '"]')?.closest(wrapperSel)
           || (() => {
-            for (const el of document.querySelectorAll('[data-flat-index]')) {
+            for (const el of document.querySelectorAll(wrapperSel)) {
               const inner = el.querySelector('[data-tool-call-id="' + tcId + '"]');
               if (inner) return el;
             }
@@ -521,9 +525,10 @@ export class CommandExecutor {
       const expanded = await this.client.evaluate(`
         (() => {
           const tcId = ${JSON.stringify(toolCallId)};
+          const wrapperSel = ${JSON.stringify(MESSAGE_WRAPPER_SELECTOR)};
           const wrapper = document.querySelector('[data-tool-call-id="' + tcId + '"]')
             || (() => {
-              for (const el of document.querySelectorAll('[data-flat-index]')) {
+              for (const el of document.querySelectorAll(wrapperSel)) {
                 const inner = el.querySelector('[data-tool-call-id="' + tcId + '"]');
                 if (inner) return el;
               }
@@ -563,9 +568,10 @@ export class CommandExecutor {
       await this.client.evaluate(`
         (() => {
           const tcId = ${JSON.stringify(toolCallId)};
+          const wrapperSel = ${JSON.stringify(MESSAGE_WRAPPER_SELECTOR)};
           const wrapper = document.querySelector('[data-tool-call-id="' + tcId + '"]')
             || (() => {
-              for (const el of document.querySelectorAll('[data-flat-index]')) {
+              for (const el of document.querySelectorAll(wrapperSel)) {
                 const inner = el.querySelector('[data-tool-call-id="' + tcId + '"]');
                 if (inner) return el;
               }

--- a/src/server/dom-extractor.ts
+++ b/src/server/dom-extractor.ts
@@ -25,8 +25,8 @@ export function cleanTabTitle(raw: string): string {
  * Runs inside Cursor's renderer process via Runtime.evaluate.
  * Must be completely self-contained (no Node.js imports).
  *
- * Uses Cursor's data attributes (data-flat-index, data-message-role,
- * data-message-kind, data-tool-status) for reliable extraction.
+ * Uses Cursor's data attributes (data-message-index or legacy data-flat-index,
+ * data-message-role, data-message-kind, data-tool-status) for reliable extraction.
  */
 export function extractionFunction(
   containerSelectors: string[],
@@ -108,7 +108,12 @@ export function extractionFunction(
     const container = findFirst(containerSelectors);
     if (!container) return null;
 
-    const flatIndexEls = container.querySelectorAll('[data-flat-index]');
+    // Cursor 3.8+ virtualized chat uses data-message-index; older builds use data-flat-index.
+    const MESSAGE_WRAPPER_SELECTOR = '[data-message-index], [data-flat-index]';
+    const messageWrapperIndex = (el: Element): number =>
+      parseInt(el.getAttribute('data-message-index') || el.getAttribute('data-flat-index') || '0', 10);
+
+    const flatIndexEls = container.querySelectorAll(MESSAGE_WRAPPER_SELECTOR);
     let containerComposerId =
       container.getAttribute('data-composer-id') ||
       container.closest('[data-composer-id]')?.getAttribute('data-composer-id') ||
@@ -862,7 +867,7 @@ export function extractionFunction(
     }
 
     for (const wrapper of Array.from(flatIndexEls)) {
-      const flatIndex = parseInt(wrapper.getAttribute('data-flat-index') || '0', 10);
+      const flatIndex = messageWrapperIndex(wrapper);
 
       const msgEl = wrapper.querySelector('[data-message-role]') || wrapper;
       const role = msgEl.getAttribute('data-message-role');
@@ -1135,11 +1140,11 @@ export function extractionFunction(
       }
     }
 
-    // --- Orphan activity indicators (not inside any [data-flat-index]) ---
+    // --- Orphan activity indicators (not inside any message wrapper) ---
     const _orphanIndicators: Array<{ cls: string; text: string; parentCls: string }> = [];
     const allIndicators = container.querySelectorAll('.loading-indicator-v3, .make-shine');
     for (const ind of Array.from(allIndicators)) {
-      if (ind.closest('[data-flat-index]')) continue;
+      if (ind.closest(MESSAGE_WRAPPER_SELECTOR)) continue;
       _orphanIndicators.push({
         cls: ind.className.substring(0, 200),
         text: (ind.textContent || '').trim().substring(0, 120),
@@ -1567,7 +1572,7 @@ export function extractionFunction(
                  sh.closest('.composer-terminal-top-header-text')) {
         text = (sh.textContent || '').trim();
       } else {
-        const descEl = (sh.closest('[data-flat-index]') || sh.parentElement)
+        const descEl = (sh.closest(MESSAGE_WRAPPER_SELECTOR) || sh.parentElement)
           ?.querySelector('.composer-terminal-top-header-description, .ui-tool-call-line-action, .ui-edit-tool-call__filename');
         text = descEl ? (descEl.textContent || '').trim() : (sh.textContent || '').trim();
       }


### PR DESCRIPTION
Cursor removed data-flat-index in favor of data-message-index; fall back to the legacy attribute so extraction works on both old and new builds.

Fixes #36 