### PR TITLE
Fix message extraction on Cursor 3.8+ when data-flat-index is absent.

### DIFF
--- a/scripts/probe-messages.ts
+++ b/scripts/probe-messages.ts
@@ -1,0 +1,101 @@
+import { CdpClient } from '../src/server/cdp-client.js';
+
+async function main() {
+  const resp = await fetch('http://127.0.0.1:9222/json');
+  const pages = (await resp.json() as Array<{ type: string; title: string; url: string; webSocketDebuggerUrl?: string }>)
+    .filter(t => t.type === 'page' && t.url.includes('workbench'));
+
+  for (const p of pages) console.log('PAGE:', p.title);
+
+  const target = pages.find(p => p.title.includes('shopi.world')) || pages[0];
+  if (!target?.webSocketDebuggerUrl) {
+    console.error('No CDP target');
+    process.exit(1);
+  }
+
+  const client = new CdpClient();
+  await client.connect(target.webSocketDebuggerUrl);
+
+  const r = await client.callFunction(() => {
+    const aux = document.querySelector('#workbench\\.parts\\.auxiliarybar');
+    const doc = document;
+    const count = (root: ParentNode, sel: string) => root.querySelectorAll(sel).length;
+
+    const samples: Array<Record<string, string | null>> = [];
+    const searchRoot = aux || doc;
+    for (const el of Array.from(searchRoot.querySelectorAll(
+      '[data-flat-index], [data-message-role], .aislash-editor-input-readonly, .aislash-editor-input, [data-tab0-role]'
+    )).slice(0, 20)) {
+      samples.push({
+        tag: el.tagName,
+        cls: String(el.className || '').slice(0, 100),
+        flat: el.getAttribute('data-flat-index'),
+        role: el.getAttribute('data-message-role') || el.getAttribute('data-tab0-role'),
+        kind: el.getAttribute('data-message-kind') || el.getAttribute('data-tab0-kind'),
+        text: (el.textContent || '').trim().slice(0, 120),
+      });
+    }
+
+    const attrHits: Record<string, number> = {};
+    for (const el of Array.from(doc.querySelectorAll('*'))) {
+      for (const a of Array.from(el.attributes)) {
+        if (/message|flat|composer|tab0|aislash/i.test(a.name)) {
+          attrHits[a.name] = (attrHits[a.name] || 0) + 1;
+        }
+      }
+    }
+
+    // Find chat scroll/list containers
+    const listCandidates: Array<{ sel: string; count: number; sampleCls: string }> = [];
+    const candidateSels = [
+      '[class*="composer-messages"]',
+      '[class*="message-list"]',
+      '[class*="chat-messages"]',
+      '[class*="conversation"]',
+      '.composer-bar',
+      '[data-composer-id]',
+      '.aislash-scroll',
+      '[class*="aislash"]',
+    ];
+    for (const sel of candidateSels) {
+      try {
+        const els = doc.querySelectorAll(sel);
+        if (els.length > 0) {
+          listCandidates.push({
+            sel,
+            count: els.length,
+            sampleCls: String((els[0] as Element).className || '').slice(0, 100),
+          });
+        }
+      } catch { /* skip */ }
+    }
+
+    return {
+      windowTitle: document.title,
+      auxBar: !!aux,
+      auxHTML: aux ? (aux as HTMLElement).innerHTML.slice(0, 500) : null,
+      inAux: {
+        flatIndex: count(aux || doc, '[data-flat-index]'),
+        messageRole: count(aux || doc, '[data-message-role]'),
+        tab0Role: count(aux || doc, '[data-tab0-role]'),
+        aislashReadonly: count(aux || doc, '.aislash-editor-input-readonly'),
+        aislashInput: count(aux || doc, '.aislash-editor-input'),
+        composerBar: count(aux || doc, '.composer-bar'),
+        markdown: count(aux || doc, '.markdown-root'),
+      },
+      inDoc: {
+        flatIndex: count(doc, '[data-flat-index]'),
+        messageRole: count(doc, '[data-message-role]'),
+        tab0Role: count(doc, '[data-tab0-role]'),
+      },
+      samples,
+      listCandidates,
+      topAttrs: Object.entries(attrHits).sort((a, b) => b[1] - a[1]).slice(0, 25),
+    };
+  }) as Record<string, unknown>;
+
+  console.log(JSON.stringify(r, null, 2));
+  client.disconnect();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/verify-extraction.ts
+++ b/scripts/verify-extraction.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { CdpClient } from '../src/server/cdp-client.js';
+import { extractionFunction } from '../src/server/dom-extractor.js';
+import type { SelectorConfig } from '../src/server/types.js';
+
+async function main() {
+  const selectors = JSON.parse(readFileSync('selectors.json', 'utf8')) as SelectorConfig;
+  const resp = await fetch('http://127.0.0.1:9222/json');
+  const pages = (await resp.json() as Array<{ type: string; title: string; url: string; webSocketDebuggerUrl?: string }>)
+    .filter(t => t.type === 'page' && t.url.includes('workbench'));
+  const target = pages.find(p => p.title.includes('shopi.world')) || pages[0];
+  if (!target?.webSocketDebuggerUrl) throw new Error('No CDP target');
+
+  const client = new CdpClient();
+  await client.connect(target.webSocketDebuggerUrl);
+
+  const state = await client.callFunction(
+    extractionFunction,
+    selectors.chatContainer.strategies,
+    selectors.approveButton.strategies,
+    selectors.approveButton.textMatch,
+    selectors.rejectButton.strategies,
+    selectors.rejectButton.textMatch,
+    selectors.chatInput.strategies,
+    selectors.agentStatus.strategies,
+    selectors.chatTabList.strategies,
+    selectors.modeDropdown.strategies,
+    selectors.modelDropdown.strategies,
+    target.title,
+  );
+
+  if (!state) {
+    console.error('extraction returned null');
+    process.exit(1);
+  }
+
+  console.log('messages:', state.messages.length);
+  console.log('types:', state.messages.map(m => m.type).join(', '));
+  const assistants = state.messages.filter(m => m.type === 'assistant');
+  if (assistants.length > 0) {
+    const last = assistants[assistants.length - 1];
+    console.log('last assistant:', (last as { text?: string }).text?.slice(0, 200));
+  }
+  client.disconnect();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/src/server/dom-extractor.ts
+++ b/src/server/dom-extractor.ts
@@ -109,12 +109,37 @@ export function extractionFunction(
     if (!container) return null;
 
     const flatIndexEls = container.querySelectorAll('[data-flat-index]');
+    // Cursor 3.8+ often omits data-flat-index; messages carry data-message-role directly
+    // on .composer-rendered-message nodes inside .composer-messages-container.
+    let messageWrappers: Element[];
+    if (flatIndexEls.length > 0) {
+      messageWrappers = Array.from(flatIndexEls);
+    } else {
+      const msgsRoot =
+        container.querySelector('.composer-messages-container') || container;
+      messageWrappers = Array.from(
+        msgsRoot.querySelectorAll('.composer-rendered-message[data-message-role]')
+      );
+      if (messageWrappers.length === 0) {
+        messageWrappers = Array.from(
+          msgsRoot.querySelectorAll('[data-message-role][data-message-id]')
+        );
+      }
+      // Drop nested duplicates (tool cards sometimes wrap an inner [data-message-role]).
+      messageWrappers = messageWrappers.filter((el) => {
+        const outer = el.parentElement?.closest(
+          '.composer-rendered-message[data-message-role]'
+        );
+        return !outer || outer === el;
+      });
+    }
+
     let containerComposerId =
       container.getAttribute('data-composer-id') ||
       container.closest('[data-composer-id]')?.getAttribute('data-composer-id') ||
       '';
-    if (!containerComposerId && flatIndexEls.length > 0) {
-      const firstMsg = flatIndexEls[0];
+    if (!containerComposerId && messageWrappers.length > 0) {
+      const firstMsg = messageWrappers[0];
       containerComposerId = firstMsg.closest('[data-composer-id]')?.getAttribute('data-composer-id') || '';
     }
 
@@ -861,8 +886,13 @@ export function extractionFunction(
       };
     }
 
-    for (const wrapper of Array.from(flatIndexEls)) {
-      const flatIndex = parseInt(wrapper.getAttribute('data-flat-index') || '0', 10);
+    for (const wrapper of messageWrappers) {
+      const flatIndex = parseInt(
+        wrapper.getAttribute('data-flat-index') ||
+          wrapper.getAttribute('data-message-index') ||
+          '0',
+        10
+      );
 
       const msgEl = wrapper.querySelector('[data-message-role]') || wrapper;
       const role = msgEl.getAttribute('data-message-role');
@@ -1139,7 +1169,7 @@ export function extractionFunction(
     const _orphanIndicators: Array<{ cls: string; text: string; parentCls: string }> = [];
     const allIndicators = container.querySelectorAll('.loading-indicator-v3, .make-shine');
     for (const ind of Array.from(allIndicators)) {
-      if (ind.closest('[data-flat-index]')) continue;
+      if (ind.closest('[data-flat-index]') || ind.closest('[data-message-role]')) continue;
       _orphanIndicators.push({
         cls: ind.className.substring(0, 200),
         text: (ind.textContent || '').trim().substring(0, 120),

--- a/src/server/transports/telegram/commands.ts
+++ b/src/server/transports/telegram/commands.ts
@@ -7,7 +7,7 @@ import type { WindowMonitor } from '../../window-monitor.js';
 import { escapeHtml, formatElement, formatPlanFull, mergeFormattedBlocks, splitMessage } from './formatter.js';
 import type { PlanBlock } from '../../types.js';
 import { cleanTabTitle } from '../../dom-extractor.js';
-import { normalizeWindowTitle } from './topic-manager.js';
+import { normalizeWindowTitle, findWindowForMapping } from './topic-manager.js';
 import { tgKeyboard, type BotContext, type TelegramApiClient } from './tg-types.js';
 
 export interface CommandDeps {
@@ -1257,20 +1257,21 @@ export async function handleTextMessage(ctx: BotContext, deps: CommandDeps): Pro
   const commandId = genId();
 
   const currentWin = state.windows.find(w => w.id === state.activeWindowId);
-  const alreadyOnWindow = currentWin && (
-    currentWin.id === mapping.windowId ||
-    currentWin.title.toLowerCase() === mapping.windowTitle.toLowerCase()
-  );
+  const mappedWin = findWindowForMapping(state.windows, mapping);
+  const alreadyOnWindow = currentWin && mappedWin && currentWin.id === mappedWin.id;
 
   if (!alreadyOnWindow) {
     await deps.cdpBridge.refreshWindows();
     deps.stateManager.updateWindows(deps.cdpBridge.windows, deps.cdpBridge.activeTargetId);
     state = deps.stateManager.getCurrentState();
 
-    let targetWin = state.windows.find(w => w.id === mapping.windowId);
-    if (!targetWin) {
-      targetWin = state.windows.find(w => w.title.toLowerCase() === mapping.windowTitle.toLowerCase());
-      if (targetWin) mapping.windowId = targetWin.id;
+    let targetWin = findWindowForMapping(state.windows, mapping);
+    if (targetWin) {
+      if (targetWin.id !== mapping.windowId || targetWin.title !== mapping.windowTitle) {
+        mapping.windowId = targetWin.id;
+        mapping.windowTitle = targetWin.title;
+        deps.topicManager.persistInPlace();
+      }
     }
 
     if (!targetWin) {

--- a/src/server/transports/telegram/topic-manager.ts
+++ b/src/server/transports/telegram/topic-manager.ts
@@ -48,6 +48,41 @@ export function normalizeWindowTitle(title: string): string {
     .trim();
 }
 
+/** e.g. "Kapps — shopi.world (Workspace)" → "shopi.world" */
+export function workspaceFolderFromTitle(title: string): string | null {
+  const norm = normalizeWindowTitle(title);
+  const m = norm.match(/—\s*(.+?)\s*\(Workspace\)\s*$/i);
+  return m ? m[1].trim().toLowerCase() : null;
+}
+
+/** Resolve a live window when windowId/title changed (rename, reinstall, extension prefix). */
+export function findWindowForMapping(
+  windows: CursorWindow[],
+  mapping: Pick<TopicMapping, 'windowId' | 'windowTitle'>,
+): CursorWindow | undefined {
+  let target = windows.find((w) => w.id === mapping.windowId);
+  if (target) return target;
+
+  const mapNorm = normalizeWindowTitle(mapping.windowTitle).toLowerCase();
+  target = windows.find(
+    (w) => normalizeWindowTitle(w.title).toLowerCase() === mapNorm,
+  );
+  if (target) return target;
+
+  target = windows.find(
+    (w) => w.title.toLowerCase() === mapping.windowTitle.toLowerCase(),
+  );
+  if (target) return target;
+
+  const mapWs = workspaceFolderFromTitle(mapping.windowTitle);
+  if (mapWs) {
+    target = windows.find((w) => workspaceFolderFromTitle(w.title) === mapWs);
+    if (target) return target;
+  }
+
+  return undefined;
+}
+
 function makeTitleKey(windowTitle: string, tabTitle: string): string {
   return `${normalizeWindowTitle(windowTitle).toLowerCase()}::${cleanTabTitle(tabTitle).toLowerCase()}`;
 }


### PR DESCRIPTION
Cursor 3.8.11+ and 3.9.x render chat messages on
.composer-rendered-message[data-message-role] without [data-flat-index] wrappers, so the extractor always reported messages: 0 and Telegram/web mirroring showed no replies. Fall back to message-role nodes inside .composer-messages-container when flat-index count is zero.

Also resolve Telegram topic windows when the workbench title changes (e.g. project rename or "Extension:" prefix) by matching the workspace folder segment before "(Workspace)".

Adds probe-messages.ts and verify-extraction.ts for CDP diagnostics.

Closes #35