### PR TITLE
fix(telegram): route questionnaire card per window so it renders in all topics

### DIFF
--- a/src/server/transports/telegram/base.ts
+++ b/src/server/transports/telegram/base.ts
@@ -845,11 +845,13 @@ export abstract class BaseTelegramTransport implements Transport {
       }
     }
 
-    // Process questionnaire using this thread's threadId (guaranteed to exist here).
-    // This ensures the questionnaire is sent even when a new topic was just created
-    // for messages (plan widget) in this same cycle.
-    const currentQuestionnaire = this.stateManager.getCurrentState().questionnaire;
-    await this.processQuestionnaireForThread(threadId, currentQuestionnaire);
+    // Process this window's questionnaire against this thread. Using the
+    // snapshot's own questionnaire (rather than the global home-window state)
+    // means the questions card reaches the correct topic even when the window
+    // is not the active CDP home window — the case where it was silently
+    // dropped before. Guaranteed threadId exists here, so a card created in the
+    // same cycle as a new topic still lands.
+    await this.processQuestionnaireForThread(threadId, snapshot.questionnaire ?? null);
   }
 
   private async sendNewMessage(

--- a/src/server/window-monitor.ts
+++ b/src/server/window-monitor.ts
@@ -14,6 +14,7 @@ import type {
   CursorState,
   ModeInfo,
   ModelInfo,
+  Questionnaire,
   ServerConfig,
   SelectorConfig,
 } from './types.js';
@@ -32,6 +33,10 @@ export interface WindowSnapshot {
   composerQueue: ComposerQueueState;
   mode: ModeInfo;
   model: ModelInfo;
+  /** Agent multiple-choice questionnaire widget for this window, if present.
+   *  Extracted per window so its card can be routed to the correct topic even
+   *  when the window is not the active CDP home window. Null when absent. */
+  questionnaire: Questionnaire | null;
   lastUpdated: number;
   /** data-composer-id of the active composer in this window. Same agent shown
    *  via Cursor's global rail in another window will share this id; two
@@ -88,6 +93,19 @@ function approvalsFingerprint(approvals: { id: string; actions: { label: string;
   return approvals
     .map((a) => `${a.id}|${a.actions.map((act) => `${act.type}:${act.label}`).join(',')}`)
     .join(';');
+}
+
+/**
+ * Stable signature over the questionnaire widget. A questionnaire appearing,
+ * changing its active question, or clearing must trigger a snapshot emit so
+ * the per-window Telegram path can send/edit/delete the questions card. The
+ * home-window fast path already handles this via state patches, but non-home
+ * windows are only surfaced through window-monitor snapshots.
+ */
+export function questionnaireFingerprint(questionnaire: Questionnaire | null): string {
+  if (!questionnaire || questionnaire.questions.length === 0) return '';
+  const q = questionnaire.questions[questionnaire.activeIndex] ?? questionnaire.questions[0];
+  return `${questionnaire.totalLabel}|${questionnaire.activeIndex}|${questionnaire.continueDisabled ? 1 : 0}|${q?.number ?? ''}|${q?.options.length ?? 0}`;
 }
 
 /**
@@ -236,6 +254,7 @@ export class WindowMonitor extends EventEmitter {
       composerQueue: state.composerQueue,
       mode: state.mode,
       model: state.model,
+      questionnaire: state.questionnaire,
       lastUpdated: Date.now(),
       activeComposerId: state.activeComposerId ?? '',
     };
@@ -245,6 +264,8 @@ export class WindowMonitor extends EventEmitter {
     const prevQueueSig = prev ? JSON.stringify(prev.composerQueue) : '';
     const approvalSig = approvalsFingerprint(snapshot.pendingApprovals);
     const prevApprovalSig = prev ? approvalsFingerprint(prev.pendingApprovals) : '';
+    const questionnaireSig = questionnaireFingerprint(snapshot.questionnaire);
+    const prevQuestionnaireSig = prev ? questionnaireFingerprint(prev.questionnaire) : '';
     const changed = !prev
       || prev.messages.length !== snapshot.messages.length
       || (prev.messages.length > 0 && prev.messages[prev.messages.length - 1]?.id !== snapshot.messages[snapshot.messages.length - 1]?.id)
@@ -253,6 +274,7 @@ export class WindowMonitor extends EventEmitter {
       || prev.agentActivityLive !== snapshot.agentActivityLive
       || prev.agentActivitySource !== snapshot.agentActivitySource
       || approvalSig !== prevApprovalSig
+      || questionnaireSig !== prevQuestionnaireSig
       || queueSig !== prevQueueSig
       || prev.mode?.current !== snapshot.mode?.current
       || prev.model?.current !== snapshot.model?.current
@@ -353,6 +375,7 @@ export class WindowMonitor extends EventEmitter {
           composerQueue: state.composerQueue,
           mode: state.mode,
           model: state.model,
+          questionnaire: state.questionnaire,
           lastUpdated: Date.now(),
           activeComposerId: state.activeComposerId ?? '',
         };
@@ -362,6 +385,8 @@ export class WindowMonitor extends EventEmitter {
         const pqSig = prev ? JSON.stringify(prev.composerQueue) : '';
         const aSig = approvalsFingerprint(snapshot.pendingApprovals);
         const paSig = prev ? approvalsFingerprint(prev.pendingApprovals) : '';
+        const qnSig = questionnaireFingerprint(snapshot.questionnaire);
+        const pqnSig = prev ? questionnaireFingerprint(prev.questionnaire) : '';
         const changed = !prev
           || prev.messages.length !== snapshot.messages.length
           || (prev.messages.length > 0 && prev.messages[prev.messages.length - 1]?.id !== snapshot.messages[snapshot.messages.length - 1]?.id)
@@ -370,6 +395,7 @@ export class WindowMonitor extends EventEmitter {
           || prev.agentActivityLive !== snapshot.agentActivityLive
           || prev.agentActivitySource !== snapshot.agentActivitySource
           || aSig !== paSig
+          || qnSig !== pqnSig
           || qSig !== pqSig
           || prev.mode?.current !== snapshot.mode?.current
           || prev.model?.current !== snapshot.model?.current

--- a/tests/window-monitor-questionnaire.test.ts
+++ b/tests/window-monitor-questionnaire.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { questionnaireFingerprint } from '../src/server/window-monitor.js';
+import type { Questionnaire } from '../src/server/types.js';
+
+function makeQuestionnaire(overrides: Partial<Questionnaire> = {}): Questionnaire {
+  return {
+    questions: [
+      {
+        number: '1.',
+        text: 'How should I re-land it?',
+        isActive: true,
+        options: [
+          { letter: 'A', label: 'Push a fresh branch', isFreeform: false, selectorPath: 'a' },
+          { letter: 'B', label: "Don't open a PR", isFreeform: false, selectorPath: 'b' },
+        ],
+      },
+    ],
+    activeIndex: 0,
+    totalLabel: '1 of 1',
+    skipSelectorPath: 'skip',
+    continueSelectorPath: 'continue',
+    continueDisabled: true,
+    ...overrides,
+  };
+}
+
+describe('questionnaireFingerprint', () => {
+  it('returns empty string for null or empty questionnaires', () => {
+    assert.equal(questionnaireFingerprint(null), '');
+    assert.equal(
+      questionnaireFingerprint(makeQuestionnaire({ questions: [] })),
+      ''
+    );
+  });
+
+  it('changes when a questionnaire first appears (drives the per-window emit)', () => {
+    const before = questionnaireFingerprint(null);
+    const after = questionnaireFingerprint(makeQuestionnaire());
+    assert.notEqual(before, after);
+  });
+
+  it('changes when the active question advances', () => {
+    const q1 = makeQuestionnaire({
+      questions: [
+        makeQuestionnaire().questions[0],
+        { number: '2.', text: 'Second?', isActive: false, options: [] },
+      ],
+      totalLabel: '1 of 2',
+      activeIndex: 0,
+    });
+    const q2 = makeQuestionnaire({
+      questions: q1.questions,
+      totalLabel: '2 of 2',
+      activeIndex: 1,
+    });
+    assert.notEqual(questionnaireFingerprint(q1), questionnaireFingerprint(q2));
+  });
+
+  it('changes when the continue button toggles enabled/disabled', () => {
+    const disabled = makeQuestionnaire({ continueDisabled: true });
+    const enabled = makeQuestionnaire({ continueDisabled: false });
+    assert.notEqual(questionnaireFingerprint(disabled), questionnaireFingerprint(enabled));
+  });
+
+  it('is stable for identical questionnaires (no spurious re-emits)', () => {
+    assert.equal(
+      questionnaireFingerprint(makeQuestionnaire()),
+      questionnaireFingerprint(makeQuestionnaire())
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The agent questionnaire widget (the multiple-choice **Questions** card) never appears in Telegram for windows that aren't the active CDP home window.

Root cause: the questionnaire is only pushed to Telegram from the home-window `state:patch` path (`onStatePatch` → `processQuestionnaire`). The multi-window monitor path (`window:update` → `doProcessWindow`) never carried it:

- `WindowSnapshot` had no `questionnaire` field, so it was never captured for non-home windows.
- `doProcessWindow` fell back to the **global** home-window questionnaire (`stateManager.getCurrentState().questionnaire`) when routing per-window, which for a non-home window is either empty (card dropped) or belongs to a different window (card routed to the wrong topic).

## Changes

- Add `questionnaire: Questionnaire | null` to `WindowSnapshot` and populate it in both capture paths (`captureHomeWindow` and `pollWindowParallel`).
- Add `questionnaireFingerprint()` and include it in the change-detection so a questionnaire appearing, advancing its active question, toggling Continue, or clearing triggers a `window:update` emit.
- In `doProcessWindow`, process the snapshot's own questionnaire against its resolved thread instead of the global state.

Dedup is preserved: `processQuestionnaireForThread` keys on `(threadId, 'questionnaire')` with a content hash, so dual-firing with the home-window state-patch path is safe.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] `npm test` — 109/109 pass, including 5 new `questionnaireFingerprint` cases in `tests/window-monitor-questionnaire.test.ts`
- [ ] Manual: trigger an agent questionnaire in a non-home Cursor window with `/sync` enabled and confirm the Questions card + inline answer buttons appear in that window's topic